### PR TITLE
Add LiteLLM - support for Vertex AI, Gemini, Anthropic, Bedrock (100+LLMs)

### DIFF
--- a/cik_benchmark/baselines/direct_prompt.py
+++ b/cik_benchmark/baselines/direct_prompt.py
@@ -18,7 +18,7 @@ from lmformatenforcer import JsonSchemaParser, RegexParser
 from lmformatenforcer.integrations.transformers import (
     build_transformers_prefix_allowed_tokens_fn,
 )
-
+import litellm
 from .base import Baseline
 from ..config import (
     LLAMA31_405B_URL,
@@ -179,6 +179,19 @@ def openrouter_client(model, messages, n=1, max_tokens=10000, temperature=1.0):
     return completion
 
 
+def litellm_client(model, messages, n=1, max_tokens=10000, temperature=1.0):
+    """
+    Client for litellm chat models
+    """
+    completion = litellm.completion(
+        model=model,
+        messages=messages,
+        n=n,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+    return completion
+
 def llama_3_1_405b_instruct_client(
     model, messages, n=1, max_tokens=10000, temperature=1.0
 ):
@@ -325,6 +338,12 @@ class DirectPrompt(Baseline):
         elif self.model.startswith("openrouter-"):
             return partial(
                 openrouter_client,
+                temperature=self.temperature,
+            )
+
+        elif self.model.startswith("litellm-"):
+            return partial(
+                litellm_client,
                 temperature=self.temperature,
             )
 


### PR DESCRIPTION
# Add LiteLLM - support for Vertex AI, Gemini, Anthropic, Bedrock (100+LLMs)

# What's changing

This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-4o.

Example

```python
from litellm import completion
import os

## set ENV variables
os.environ["OPENAI_API_KEY"] = "your-openai-key"
os.environ["ANTHROPIC_API_KEY"] = "your-cohere-key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="openai/gpt-4o", messages=messages)

# anthropic call
response = completion(model="anthropic/claude-3-sonnet-20240229", messages=messages)
print(response)
```

### Response (OpenAI Format)

```json
{
    "id": "chatcmpl-565d891b-a42e-4c39-8d14-82a1f5208885",
    "created": 1734366691,
    "model": "claude-3-sonnet-20240229",
    "object": "chat.completion",
    "system_fingerprint": null,
    "choices": [
        {
            "finish_reason": "stop",
            "index": 0,
            "message": {
                "content": "Hello! As an AI language model, I don't have feelings, but I'm operating properly and ready to assist you with any questions or tasks you may have. How can I help you today?",
                "role": "assistant",
                "tool_calls": null,
                "function_call": null
            }
        }
    ],
    "usage": {
        "completion_tokens": 43,
        "prompt_tokens": 13,
        "total_tokens": 56,
        "completion_tokens_details": null,
        "prompt_tokens_details": {
            "audio_tokens": null,
            "cached_tokens": 0
        },
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0
    }
}
```

